### PR TITLE
ci: add workflow_dispatch trigger to dependabot config

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -3,7 +3,7 @@ name: Dependabot PR auto-merge
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  workflow_dispatch: 
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request makes a small update to the Dependabot PR auto-merge workflow, allowing it to be triggered manually via the GitHub Actions UI.