### PR TITLE
Run CI checks for recipe files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,14 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install just
+        uses: extractions/setup-just@v3
+
       - name: Run ruff linter
-        run: uv run --frozen --no-dev --group quality ruff check
+        run: just lint-check
 
       - name: Run ruff formatter
-        run: uv run --frozen --no-dev --group quality ruff format --check
+        run: just format-check
 
   type-check:
     needs: bots_guard
@@ -55,10 +58,11 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install just
+        uses: extractions/setup-just@v3
+
       - name: Run type checker
-        run: >-
-          uv run --frozen --no-dev --group quality --group test
-          --extra torch-cpu ty check
+        run: just typecheck
 
   test:
     needs: bots_guard
@@ -78,7 +82,8 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install just
+        uses: extractions/setup-just@v3
+
       - name: Run tests
-        run: >-
-          uv run --frozen --no-dev --group test --extra torch-cpu
-          pytest -m "not legacy_tf" -rs -v --tb=short tests/
+        run: just test


### PR DESCRIPTION
This pull request updates the CI workflow to use `just` for running linting, formatting, type checking, and tests instead of invoking commands directly. It also adds a step to install `just` in each relevant job. This change centralizes and simplifies command execution in the CI pipeline.

**CI workflow modernization:**

* Added a step to install `just` using the `extractions/setup-just@v3` GitHub Action in the `lint`, `type-check`, and `test` jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR34-R41) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR61-R65) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR85-R89)
* Replaced direct `uv run` commands for linting, formatting, type checking, and testing with `just` commands (`just lint-check`, `just format-check`, `just typecheck`, and `just test`) to standardize and simplify job steps. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR34-R41) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR61-R65) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR85-R89)